### PR TITLE
Add `FieldName` type extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## v0.3.0 (2024-11-03)
+## v0.3.0 (2024-11-05)
 * Added `Paradex.extensions/1` which presently consists of `[ Paradex.FieldName ]`.
   * This allows Postgrex to parameterize field names in ParadeDB query objects, solving issue [#4](https://github.com/Moosieus/paradex/issues/4).
 * Updated docs to include instructions for the above.
+
+*If you've configured everything correctly and are receiving an error that `fieldname` doesn't exist, try updating ParadeDB.*
 
 ## v0.2.0 (2024-10-27)
 * Added `lenient` and `conjunction_mode` options to `parse` (non-breaking).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.0 (2024-11-03)
+* Added `Paradex.extensions/1` which presently consists of `[ Paradex.FieldName ]`.
+  * This allows Postgrex to parameterize field names in ParadeDB query objects, solving issue [#4](https://github.com/Moosieus/paradex/issues/4).
+* Updated docs to include instructions for the above.
+
 ## v0.2.0 (2024-10-27)
 * Added `lenient` and `conjunction_mode` options to `parse` (non-breaking).
 * Added `lenient` option to `parse_with_field` as the 2nd argument, making `conjunction_mode` the 3rd (minor breaking change).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Postgrex.Types.define(
 
 Add the following to `config/config.exs`:
 ```elixir
-config :my_app, MyApp.repo, types: MyApp.PostgrexTypes
+config :my_app, MyApp.Repo, types: MyApp.PostgrexTypes
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `:paradex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:paradex, "~> 0.2.0"}
+    {:paradex, "~> 0.3.0"}
   ]
 end
 ```
@@ -20,9 +20,27 @@ Documentation is available on [HexDocs](https://hexdocs.pm/paradex/readme.html) 
 
 ## Usage
 
-* Create your [Ecto schema](https://github.com/Moosieus/paradex/blob/main/test/support/paradex_app/call.ex).
-* Create a [search index](https://docs.paradedb.com/documentation/indexing/create_index) in your [migrations](https://github.com/Moosieus/paradex/blob/main/priv/repo/migrations/20241013014316_setup.exs).
-* Run search queries.
+You may install ParadeDB via [Docker](https://docs.paradedb.com/documentation/getting-started/install), or by [loading the extensions](https://docs.paradedb.com/deploy/self-hosted/extensions) into an existing Postgres database.
+
+Create `lib/postgrex_types.ex` with the contents below. You may omit `Pgvector.extensions()` if you aren't working with vectors:
+
+```elixir
+Postgrex.Types.define(
+  ParadexApp.PostgrexTypes,
+  Pgvector.extensions() ++ Paradex.extensions() ++ Ecto.Adapters.Postgres.extensions(),
+  []
+)
+```
+
+Add the following to `config/config.exs`:
+```elixir
+config :my_app, MyApp.repo, types: MyApp.PostgrexTypes
+```
+
+
+Create your [Ecto schema](https://github.com/Moosieus/paradex/blob/main/test/support/paradex_app/call.ex) and a [search index](https://docs.paradedb.com/documentation/indexing/create_index) in your [migrations](https://github.com/Moosieus/paradex/blob/main/priv/repo/migrations/20241013014316_setup.exs).
+
+Once complete, you're ready to run search queries:
 
 ```elixir
 import Ecto.Query

--- a/lib/paradex.ex
+++ b/lib/paradex.ex
@@ -4,6 +4,15 @@ defmodule Paradex do
   """
 
   @doc """
+  Extensions for Postgrex
+  """
+  def extensions do
+    [
+      Paradex.FieldName
+    ]
+  end
+
+  @doc """
   Macro for the [`@@@`](https://docs.paradedb.com/documentation/full-text/overview#basic-usage) full text search operator.
 
   `~>` is used as it's one of a few infix operators Elixir's capable of parsing, but aren't presently used.
@@ -117,7 +126,7 @@ defmodule Paradex do
   @doc section: :term_level_queries
   defmacro pdb_exists(field) do
     quote do
-      fragment("paradedb.exists(?)", unquote(field))
+      fragment("paradedb.exists(?::fieldname)", unquote(field))
     end
   end
 
@@ -133,7 +142,7 @@ defmodule Paradex do
   defmacro fuzzy_term(field, value, distance \\ 2, transpose_cost_one \\ true, prefix \\ false) do
     quote do
       fragment(
-        "paradedb.fuzzy_term(?, ?, ?, ?, ?)",
+        "paradedb.fuzzy_term(?::fieldname, ?, ?, ?, ?)",
         unquote(field),
         unquote(value),
         unquote(distance),
@@ -150,7 +159,7 @@ defmodule Paradex do
   defmacro range_term(field, value) do
     quote do
       fragment(
-        "paradedb.range_term(?, ?)",
+        "paradedb.range_term(?::fieldname, ?)",
         unquote(field),
         unquote(value)
       )
@@ -169,7 +178,7 @@ defmodule Paradex do
   defmacro regex(field, pattern) do
     quote do
       fragment(
-        "paradedb.regex(?, ?)",
+        "paradedb.regex(?::fieldname, ?)",
         unquote(field),
         unquote(pattern)
       )
@@ -188,7 +197,7 @@ defmodule Paradex do
   defmacro term(field, value) do
     quote do
       fragment(
-        "paradedb.term(?, ?)",
+        "paradedb.term(?::fieldname, ?)",
         unquote(field),
         unquote(value)
       )
@@ -232,7 +241,7 @@ defmodule Paradex do
   defmacro int4range(field, min, max, bounds) do
     quote do
       fragment(
-        "paradedb.range(field => ?, range => int4range(?, ?, ?))",
+        "paradedb.range(field => ?::fieldname, range => int4range(?, ?, ?))",
         unquote(field),
         unquote(min),
         unquote(max),
@@ -253,7 +262,7 @@ defmodule Paradex do
   defmacro int8range(field, min, max, bounds) do
     quote do
       fragment(
-        "paradedb.range(field => ?, range => int8range(?, ?, ?))",
+        "paradedb.range(field => ?::fieldname, range => int8range(?, ?, ?))",
         unquote(field),
         unquote(min),
         unquote(max),
@@ -278,7 +287,7 @@ defmodule Paradex do
   defmacro daterange(field, min, max, bounds) do
     quote do
       fragment(
-        "paradedb.range(field => ?, range => daterange(?, ?, ?))",
+        "paradedb.range(field => ?::fieldname, range => daterange(?, ?, ?))",
         unquote(field),
         unquote(min),
         unquote(max),
@@ -302,7 +311,7 @@ defmodule Paradex do
   defmacro tsrange(field, min, max, bounds) do
     quote do
       fragment(
-        "paradedb.range(field => ?, range => tsrange(?, ?, ?))",
+        "paradedb.range(field => ?::fieldname, range => tsrange(?, ?, ?))",
         unquote(field),
         unquote(min),
         unquote(max),
@@ -334,7 +343,7 @@ defmodule Paradex do
            ) do
     quote do
       fragment(
-        "paradedb.fuzzy_phrase(?, ?, ?, ?, ?, ?)",
+        "paradedb.fuzzy_phrase(?::fieldname, ?, ?, ?, ?, ?)",
         unquote(field),
         unquote(value),
         unquote(distance),
@@ -357,7 +366,7 @@ defmodule Paradex do
   defmacro phrase(field, phrases, slop \\ 0) do
     quote do
       fragment(
-        "paradedb.phrase(?, ?, ?)",
+        "paradedb.phrase(?::fieldname, ?, ?)",
         unquote(field),
         unquote(phrases),
         unquote(slop)
@@ -377,7 +386,7 @@ defmodule Paradex do
   defmacro phrase_prefix(field, phrases, max_expansion \\ 0) do
     quote do
       fragment(
-        "paradedb.phrase_prefix(?, ?, ?)",
+        "paradedb.phrase_prefix(?::fieldname, ?, ?)",
         unquote(field),
         unquote(phrases),
         unquote(max_expansion)
@@ -546,7 +555,7 @@ defmodule Paradex do
   defmacro parse_with_field(field, query, lenient \\ false, conjunction_mode \\ true) do
     quote do
       fragment(
-        "paradedb.parse_with_field(?, ?, lenient => ?, conjunction_mode => ?)",
+        "paradedb.parse_with_field(?::fieldname, ?, lenient => ?, conjunction_mode => ?)",
         unquote(field),
         unquote(query),
         unquote(lenient),

--- a/lib/paradex/field_name.ex
+++ b/lib/paradex/field_name.ex
@@ -1,0 +1,31 @@
+defmodule Paradex.FieldName do
+  @behaviour Postgrex.Extension
+
+  import Postgrex.BinaryUtils, warn: false
+
+  # Postgres column names are limited to 59 characters ~r/[a-zA-Z0-9_]/ so
+  # they always fall below Erlang's 64 byte threshold for reference counting.
+
+  @impl true
+  def init(_opts), do: nil
+
+  @impl true
+  def matching(_state), do: [type: "fieldname"]
+
+  @impl true
+  def format(_state), do: :text
+
+  @impl true
+  def encode(_state) do
+    quote do
+      bin when is_binary(bin) -> [<<byte_size(bin)::int32()>> | bin]
+    end
+  end
+
+  @impl true
+  def decode(_state) do
+    quote do
+      <<len::int32(), bin::binary-size(len)>> -> bin
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Paradex.MixProject do
   use Mix.Project
 
   @name "Paradex"
-  @version "0.2.0"
+  @version "0.3.0"
   @source_url "https://github.com/Moosieus/paradex"
 
   def project do

--- a/test/paradex_test.exs
+++ b/test/paradex_test.exs
@@ -23,6 +23,23 @@ defmodule ParadexTest do
     assert Repo.all(query) == [215]
   end
 
+  test "field names are successfully parameterized" do
+    field = "transcript"
+
+    query =
+      from(
+        c in Call,
+        select: count(),
+        where: c.id ~> parse_with_field(^field, "bus")
+      )
+
+    sql = ~s[SELECT count(*) FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.parse_with_field($1::fieldname, 'bus', lenient => FALSE, conjunction_mode => TRUE))]
+
+    assert_sql(query, sql)
+
+    assert Repo.all(query) == [215]
+  end
+
   test "snippet/1 generates a query" do
     query =
       from(
@@ -147,7 +164,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0.\"id\" FROM \"calls\" AS c0 WHERE (c0.\"id\" @@@ paradedb.disjunction_max(ARRAY[paradedb.parse('transcript:bus', lenient => FALSE, conjunction_mode => TRUE),paradedb.range(field => 'call_length', range => int4range(10, NULL, '[)'))], 0.0::float::real))}
+      ~s{SELECT c0.\"id\" FROM \"calls\" AS c0 WHERE (c0.\"id\" @@@ paradedb.disjunction_max(ARRAY[paradedb.parse('transcript:bus', lenient => FALSE, conjunction_mode => TRUE),paradedb.range(field => 'call_length'::fieldname, range => int4range(10, NULL, '[)'))], 0.0::float::real))}
 
     assert_sql(query, sql)
 
@@ -179,7 +196,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.exists('call_length'))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.exists('call_length'::fieldname))}
 
     assert_sql(query, sql)
 
@@ -195,7 +212,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.fuzzy_term('transcript', 'bus', 2, TRUE, FALSE))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.fuzzy_term('transcript'::fieldname, 'bus', 2, TRUE, FALSE))}
 
     assert_sql(query, sql)
 
@@ -211,7 +228,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.fuzzy_phrase('transcript', 'bus sotp', 1, FALSE, FALSE, FALSE))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.fuzzy_phrase('transcript'::fieldname, 'bus sotp', 1, FALSE, FALSE, FALSE))}
 
     assert_sql(query, sql)
 
@@ -247,7 +264,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.parse_with_field('transcript', 'traffic congestion', lenient => TRUE, conjunction_mode => FALSE))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.parse_with_field('transcript'::fieldname, 'traffic congestion', lenient => TRUE, conjunction_mode => FALSE))}
 
     assert_sql(query, sql)
 
@@ -263,7 +280,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.phrase('transcript', ARRAY['bus','stop'], 1))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.phrase('transcript'::fieldname, ARRAY['bus','stop'], 1))}
 
     assert_sql(query, sql)
 
@@ -279,7 +296,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.phrase_prefix('transcript', ARRAY['en'], 0))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.phrase_prefix('transcript'::fieldname, ARRAY['en'], 0))}
 
     assert_sql(query, sql)
 
@@ -295,7 +312,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.range(field => 'call_length', range => int4range(5, NULL, '[)')))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.range(field => 'call_length'::fieldname, range => int4range(5, NULL, '[)')))}
 
     assert_sql(query, sql)
 
@@ -311,7 +328,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.range(field => 'call_length', range => int8range(5, NULL, '[)')))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.range(field => 'call_length'::fieldname, range => int8range(5, NULL, '[)')))}
 
     assert_sql(query, sql)
 
@@ -330,7 +347,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.range(field => 'start_time', range => daterange($1, $2, '[]')))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.range(field => 'start_time'::fieldname, range => daterange($1, $2, '[]')))}
 
     assert_sql(query, sql)
 
@@ -348,7 +365,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.range(field => 'start_time', range => tsrange($1, NULL, '[)')))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.range(field => 'start_time'::fieldname, range => tsrange($1, NULL, '[)')))}
 
     assert_sql(query, sql)
 
@@ -364,7 +381,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.regex('transcript', 'bus (stop|route)'))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.regex('transcript'::fieldname, 'bus (stop|route)'))}
 
     assert_sql(query, sql)
 
@@ -380,7 +397,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT count(*) FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.term('talkgroup_num', 7695))}
+      ~s{SELECT count(*) FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.term('talkgroup_num'::fieldname, 7695))}
 
     assert_sql(query, sql)
 
@@ -401,7 +418,7 @@ defmodule ParadexTest do
       )
 
     sql =
-      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.term_set(terms => ARRAY[paradedb.term('talk_group_id', 144),paradedb.term('talk_group_id', 145)]))}
+      ~s{SELECT c0."id" FROM "calls" AS c0 WHERE (c0."id" @@@ paradedb.term_set(terms => ARRAY[paradedb.term('talk_group_id'::fieldname, 144),paradedb.term('talk_group_id'::fieldname, 145)]))}
 
     assert_sql(query, sql)
 

--- a/test/support/paradex_app/postgrex_types.ex
+++ b/test/support/paradex_app/postgrex_types.ex
@@ -1,5 +1,5 @@
 Postgrex.Types.define(
   ParadexApp.PostgrexTypes,
-  Pgvector.extensions() ++ Ecto.Adapters.Postgres.extensions(),
+  Pgvector.extensions() ++ Paradex.extensions() ++ Ecto.Adapters.Postgres.extensions(),
   []
 )


### PR DESCRIPTION
* Added `Paradex.extensions/1` which presently consists of `[ Paradex.FieldName ]`.
  * This allows Postgrex to parameterize field names in ParadeDB query objects, solving issue [#4](https://github.com/Moosieus/paradex/issues/4).
* Updated docs to include instructions for the above.

*If you've configured everything correctly and are receiving an error that `fieldname` doesn't exist, try updating ParadeDB.*